### PR TITLE
Prefer standard shards semantics in native setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ sudo mv amber amber-lsp /usr/local/bin/
 **Windows:**
 Use WSL2 or a virtual machine. Native Windows support is not currently available.
 
+### Package Manager Compatibility
+
+Amber CLI is designed to work with upstream `crystal-lang/shards`, and we also
+validate it against the additive fork currently distributed as `shards-alpha`.
+The goal is straightforward: standard Amber workflows should continue to work
+with plain `shards` commands, while compatible forks can add tooling without
+changing how a new Amber project gets started.
+
 ### Create Your First App
 
 ```bash

--- a/src/amber_cli/generators/native_app.cr
+++ b/src/amber_cli/generators/native_app.cr
@@ -243,7 +243,7 @@ all: macos
 # --- First-time setup ---
 
 setup:
-	shards-alpha install || shards install || true
+	shards install || shards-alpha install || true
 	@# crystal-audio shard name has a hyphen but source uses underscore
 	@# Crystal's require resolution needs the underscore directory
 	@if [ ! -e lib/crystal_audio ]; then \\


### PR DESCRIPTION
## Summary

Document Amber CLI's compatibility target for upstream Shards plus the additive fork currently distributed as `shards-alpha`, and make the native scaffold prefer `shards install` before falling back to the fork's current binary name.

## Why

If the fork is truly compatible, Amber should keep teaching the standard `shards` workflow first. The CLI only needs a light adjustment here, but it helps keep the public story clean while the fork grows stronger compatibility guardrails.

## Decision Record

The generated app should center the standard Shards command path and let PATH or a fallback handle compatible forks. That keeps onboarding stable for new Amber users while still tolerating the current `shards-alpha` distribution name.

## Verification

- `git diff --check`
- `AMBER_CLI_PATH=../amber_cli CRYSTAL_OPTS='--link-flags=-fuse-ld=ld' ../shards/scripts/validate_amber_cli_compatibility.sh`

## Release Impact

This keeps Amber's generated native setup aligned with the compatibility contract now enforced in the Shards fork.

## Risks And Rollback

The main risk is very small: a machine with only `shards-alpha` installed still depends on the fallback branch of the setup command. If that becomes noisy, this is easy to revert without affecting the broader compatibility work.
