### PR TITLE
docs(core): add AGENTS.md for AI assistance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AI Agent Guidelines for Amber CLI
+
+Welcome, fellow agents! When working on the `amber_cli` project, please adhere to the following principles to ensure high-quality and safe contributions:
+
+- **This is Crystal, not Ruby.** Do not use Ruby-isms or dynamic meta-programming hacks. Respect the type system and compiled nature of Crystal.
+- **Always run `ameba`** to verify linting and formatting before committing. Code should conform to the standard style.
+- **Always run `crystal spec`** to ensure tests pass. No PR should break the test suite.
+- **Avoid unsafe `.not_nil!` assertions.** Use proper type narrowing (e.g., `if let`, `.try`, `.as?`) to handle `nil` values gracefully.
+- **Prefer modern Crystal 1.20 features and modern Process API (RFC 0025)** instead of `shell: true` when spawning external commands. Ensure determinism and security.
+- **Do not use deprecated `yaml_mapping` or `json_mapping`.** Use `YAML::Serializable` and `JSON::Serializable` instead.
+
+By following these rules, we maintain robust, readable, and idiomatic Crystal code. Let's build a great CLI together!


### PR DESCRIPTION
Hi team! This PR adds an `AGENTS.md` file to guide AI assistants in contributing idiomatic, safe Crystal code to the `amber_cli` project. It captures key project standards, such as avoiding `.not_nil!`, running tests and linters, and leveraging modern Crystal features.

Hopefully, this will help streamline any future AI-assisted contributions. Thanks for maintaining this awesome project!

Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>