### PR TITLE
ux: add accessible labels to generated scaffold views

### DIFF
--- a/src/amber_cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber_cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -17,6 +17,7 @@
   <div class="form-group">
 <% case field.type
    when "text" -%>
+    <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
   <%="<"%>%= label(<%=":#{field.name}"%>) do
@@ -27,6 +28,7 @@
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <% if config.model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>
 <% else -%>
+    <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control") -%>
 <% end -%>
   </div>

--- a/src/amber_cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber_cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -9,6 +9,7 @@
   .form-group
   <%- case field.type
      when "text" -%>
+    == label(<%=":#{field.name}"%>)
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
   <%- when "boolean" -%>
       == label(<%=":#{field.name}"%>) do
@@ -17,6 +18,7 @@
     == label(<%=":#{field.name}"%>)
     == select_field(name: "<%= field.name %>_id", collection: <% if config.model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")
   <%- else -%>
+    == label(<%=":#{field.name}"%>)
     == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Adds proper label elements to default text and textarea inputs in ECR and Slang scaffold view templates.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>