### PR TITLE
security: register SecureHeaders pipe in routes template

### DIFF
--- a/src/amber_cli/templates/app/config/routes.cr.ecr
+++ b/src/amber_cli/templates/app/config/routes.cr.ecr
@@ -10,6 +10,7 @@ Amber::Server.configure do
     plug Amber::Pipe::Session.new
     plug Amber::Pipe::Flash.new
     plug Amber::Pipe::CSRF.new
+    plug Amber::Pipe::SecureHeaders.new
   end
 
   pipeline :api do


### PR DESCRIPTION
Enables the `SecureHeaders` pipe in the generated application route template (`routes.cr.ecr`) by default in the `:web` pipeline.

This completes the registration of the `SecureHeaders` pipe (which was added in the core framework in `amberframework/amber#1390`) so that newly generated apps will benefit from baseline security headers (XSS, Frame Options, nosniff, HSTS) out of the box.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>