### PR TITLE
Document formula-scoped Homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ Prerequisites: Crystal 1.20 or newer (but earlier than 2.0), `shards`, and Git.
 
 ### Homebrew on macOS or Linux
 
-The tap name contains an underscore; the formula is named `amber`:
+The tap and formula names contain underscores; the installed executable is
+`amber`:
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber --version
 ```
+
+The fully qualified command follows Homebrew's tap-trust model and trusts only
+the `amber_cli` formula.
 
 ### Direct release archive
 

--- a/RELEASE_NOTES_V2.0.2.md
+++ b/RELEASE_NOTES_V2.0.2.md
@@ -6,8 +6,7 @@ Amber CLI 2.0.2 is the supported standalone CLI for Amber
 ## Install
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber --version
 ```
 

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -9,8 +9,12 @@ test "$cli_version" = "$shard_version"
 grep -F 'github: amberframework/amber' src/amber_cli/commands/new.cr
 grep -F 'version: 2.0.0-beta.2' src/amber_cli/commands/new.cr
 grep -F 'template: ecr' src/amber_cli/commands/new.cr
-grep -F 'brew tap amberframework/amber_cli' README.md
-grep -F 'brew install amber_cli' README.md
+grep -F 'brew install amberframework/amber_cli/amber_cli' README.md
+
+if grep -Ein 'brew tap amberframework/amber_cli|brew install amber_cli' README.md RELEASE_NOTES_V2.0.2.md docs/*.md; then
+  echo "Amber CLI docs contain an untrusted or incomplete Homebrew install path" >&2
+  exit 1
+fi
 
 if grep -Eir 'crimson-knight/(amber|grant|gemma)' src/amber_cli/templates/app src/amber_cli/commands/new.cr; then
   echo "supported web template contains a personal dependency" >&2


### PR DESCRIPTION
## Summary
- use the fully qualified Homebrew formula install in README and 2.0.2 release notes
- clarify tap/formula names versus the installed `amber` executable
- make the CLI docs contract reject incomplete untrusted-tap instructions

## Why
The 2.0.2 install gate showed that current Homebrew refuses an unqualified formula from an untrusted third-party tap. A fully qualified install trusts only this formula.

## Validation
- beta docs contract passes
- Crystal 1.21 format check passes