### PR TITLE
Verify generated web apps on ARM Linux and Windows

### DIFF
--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -1,0 +1,52 @@
+name: Generated Web App Platform Compile
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  linux-arm64:
+    name: Linux ARM64 generated web app
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@d8ef131ecec0352ce0e39b81b0a6d95def58fe2f # v1
+        with:
+          crystal: latest
+
+      - name: Install CLI dependencies
+        run: shards install
+
+      - name: Build Amber CLI
+        run: crystal build src/amber_cli.cr --no-debug -o amber
+
+      - name: Compile generated Amber V2 web app
+        run: scripts/smoke_generated_web.sh ./amber
+
+  windows-x86-64:
+    name: Windows x86_64 generated web app
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@d8ef131ecec0352ce0e39b81b0a6d95def58fe2f # v1
+        with:
+          crystal: latest
+
+      - name: Install CLI dependencies
+        run: shards install
+
+      - name: Build Amber CLI
+        run: crystal build src/amber_cli.cr --no-debug -o amber.exe
+
+      - name: Compile generated Amber V2 web app
+        shell: pwsh
+        run: scripts/smoke_generated_web.ps1 ./amber.exe

--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -41,6 +41,13 @@ jobs:
         with:
           crystal: latest
 
+      - name: Install Windows native libraries
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install sqlite3:x64-windows
+          "CRYSTAL_LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib" >> $env:GITHUB_ENV
+          "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
+
       - name: Install CLI dependencies
         run: shards install
 

--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -45,7 +45,8 @@ jobs:
         shell: pwsh
         run: |
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install sqlite3:x64-windows
-          "CRYSTAL_LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib" >> $env:GITHUB_ENV
+          $crystalLibraryPath = (& crystal env CRYSTAL_LIBRARY_PATH).Trim()
+          "CRYSTAL_LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib;$crystalLibraryPath" >> $env:GITHUB_ENV
           "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
 
       - name: Install CLI dependencies

--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -30,7 +30,7 @@ jobs:
         run: scripts/smoke_generated_web.sh ./amber
 
   windows-x86-64:
-    name: Windows x86_64 generated web app
+    name: Windows x86_64 generated web app (candidate framework fix)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -57,4 +57,4 @@ jobs:
 
       - name: Compile generated Amber V2 web app
         shell: pwsh
-        run: scripts/smoke_generated_web.ps1 ./amber.exe
+        run: scripts/smoke_generated_web.ps1 ./amber.exe c95090f752f4cd01c0762c65e6398456631c2c0e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
           - target: linux-x86_64
             os: ubuntu-latest
             crystal_arch: x86_64
+          - target: linux-arm64
+            os: ubuntu-24.04-arm
+            crystal_arch: aarch64
     
     steps:
     - name: Checkout code
@@ -36,7 +39,7 @@ jobs:
         ref: ${{ github.event.release.tag_name || github.event.inputs.ref }}
 
     - name: Install Crystal (Linux)
-      if: matrix.target == 'linux-x86_64'
+      if: startsWith(matrix.target, 'linux-')
       uses: crystal-lang/install-crystal@v1
       with:
         crystal: latest
@@ -63,8 +66,8 @@ jobs:
           shards install
         fi
     
-    - name: Build binaries (Linux x86_64)
-      if: matrix.target == 'linux-x86_64'
+    - name: Build binaries (Linux)
+      if: startsWith(matrix.target, 'linux-')
       run: |
         crystal build src/amber_cli.cr -o amber --release --static
         crystal build src/amber_lsp.cr -o amber-lsp --release --static
@@ -135,7 +138,9 @@ jobs:
           artifacts/amber_cli-darwin-arm64/amber_cli-darwin-arm64.tar.gz \
           artifacts/amber_cli-darwin-arm64/amber_cli-darwin-arm64.tar.gz.sha256 \
           artifacts/amber_cli-linux-x86_64/amber_cli-linux-x86_64.tar.gz \
-          artifacts/amber_cli-linux-x86_64/amber_cli-linux-x86_64.tar.gz.sha256; do
+          artifacts/amber_cli-linux-x86_64/amber_cli-linux-x86_64.tar.gz.sha256 \
+          artifacts/amber_cli-linux-arm64/amber_cli-linux-arm64.tar.gz \
+          artifacts/amber_cli-linux-arm64/amber_cli-linux-arm64.tar.gz.sha256; do
           if [ ! -f "$f" ]; then
             echo "ERROR: expected file not found: $f"
             echo "Artifact tree:"
@@ -153,6 +158,8 @@ jobs:
           artifacts/amber_cli-darwin-arm64/amber_cli-darwin-arm64.tar.gz.sha256
           artifacts/amber_cli-linux-x86_64/amber_cli-linux-x86_64.tar.gz
           artifacts/amber_cli-linux-x86_64/amber_cli-linux-x86_64.tar.gz.sha256
+          artifacts/amber_cli-linux-arm64/amber_cli-linux-arm64.tar.gz
+          artifacts/amber_cli-linux-arm64/amber_cli-linux-arm64.tar.gz.sha256
         tag_name: ${{ github.event.release.tag_name }}
         fail_on_unmatched_files: true
       env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ creates the supported Amber `2.0.0-beta.2` ECR web application and includes
 development, generator, database, and LSP tooling.
 
 Amber V2 is a beta. The release-gated path is a web application on Apple
-Silicon macOS or x86_64 Linux. See [Generator support](docs/GENERATOR_SUPPORT.md)
+Silicon macOS or x86_64 Linux. Linux ARM64 generated-app compilation is checked
+in CI; its first direct archive will ship with the next CLI release. See [Generator support](docs/GENERATOR_SUPPORT.md)
 before relying on persistence, authentication, API-resource, or native output.
 
 ## Install
@@ -30,7 +31,10 @@ the `amber_cli` formula.
 
 ### Direct release archive
 
-Use `darwin-arm64` on Apple Silicon macOS or `linux-x86_64` on x86_64 Linux:
+CLI `2.0.3` publishes `darwin-arm64` for Apple Silicon macOS and
+`linux-x86_64` for x86_64 Linux. The release workflow now also builds
+`linux-arm64`; that archive becomes available with the next published CLI
+version.
 
 ```bash
 version=v2.0.3

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ amber --version
 On Linux, use `sha256sum -c` for the checksum. Prefix only the `install`
 command with `sudo` if `/usr/local/bin` is not writable.
 
+### Linux ARM64 source install for 2.0.3
+
+CLI `2.0.3` does not contain a `linux-arm64` archive. On an ARM64 Linux host,
+build that tagged source instead of downloading the x86_64 binary:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libsqlite3-dev
+git clone --branch v2.0.3 --depth 1 https://github.com/amberframework/amber_cli.git
+cd amber_cli
+shards install --production
+crystal build src/amber_cli.cr -o amber --release
+crystal build src/amber_lsp.cr -o amber-lsp --release
+sudo install -m 0755 amber amber-lsp /usr/local/bin/
+amber --version
+```
+
+Run the clone command from a directory where the temporary `amber_cli/`
+checkout can be created. The next CLI release workflow now builds and smoke
+tests a native `linux-arm64` archive on a GitHub-hosted ARM64 Linux runner.
+
 ## Create and verify a web app
 
 ```bash

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -30,7 +30,14 @@ case "${OS}" in
     fi
     ;;
   "linux")
-    TARGET="linux-x86_64"
+    case "${ARCH}" in
+      "x86_64"|"amd64") TARGET="linux-x86_64" ;;
+      "aarch64"|"arm64") TARGET="linux-arm64" ;;
+      *)
+        echo "❌ Unsupported Linux architecture: ${ARCH}"
+        exit 1
+        ;;
+    esac
     BUILD_CLI="crystal build src/amber_cli.cr -o amber --release --static"
     BUILD_LSP="crystal build src/amber_lsp.cr -o amber-lsp --release --static"
     CHECKSUM_CMD="sha256sum"

--- a/scripts/smoke_generated_web.ps1
+++ b/scripts/smoke_generated_web.ps1
@@ -1,0 +1,41 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$Cli
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Command,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Arguments
+  )
+
+  & $Command @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Command failed with exit code $LASTEXITCODE"
+  }
+}
+
+$cliPath = (Resolve-Path $Cli).Path
+$smokeRoot = Join-Path $env:RUNNER_TEMP "amber-v2-windows-smoke"
+$appPath = Join-Path $smokeRoot "amber_beta_smoke"
+
+if (Test-Path $smokeRoot) {
+  Remove-Item -Recurse -Force $smokeRoot
+}
+New-Item -ItemType Directory -Force $smokeRoot | Out-Null
+
+Invoke-Checked $cliPath new $appPath --type web --no-deps
+
+Push-Location $appPath
+try {
+  Invoke-Checked shards install
+  Invoke-Checked crystal spec
+  New-Item -ItemType Directory -Force bin | Out-Null
+  Invoke-Checked crystal build src/amber_beta_smoke.cr -o bin/amber_beta_smoke.exe
+} finally {
+  Pop-Location
+}

--- a/scripts/smoke_generated_web.ps1
+++ b/scripts/smoke_generated_web.ps1
@@ -30,7 +30,7 @@ if (Test-Path $smokeRoot) {
 }
 New-Item -ItemType Directory -Force $smokeRoot | Out-Null
 
-Invoke-Checked $cliPath new $appPath --type web --no-deps
+Invoke-Checked -Command $cliPath -Arguments @("new", $appPath, "--type", "web", "--no-deps")
 
 if ($FrameworkCommit) {
   $shardPath = Join-Path $appPath "shard.yml"
@@ -48,10 +48,15 @@ if ($FrameworkCommit) {
 
 Push-Location $appPath
 try {
-  Invoke-Checked shards install
-  Invoke-Checked crystal spec
+  Invoke-Checked -Command "shards" -Arguments @("install")
+  Invoke-Checked -Command "crystal" -Arguments @("spec")
   New-Item -ItemType Directory -Force bin | Out-Null
-  Invoke-Checked crystal build src/amber_beta_smoke.cr -o bin/amber_beta_smoke.exe
+  Invoke-Checked -Command "crystal" -Arguments @(
+    "build",
+    "src/amber_beta_smoke.cr",
+    "-o",
+    "bin/amber_beta_smoke.exe"
+  )
 } finally {
   Pop-Location
 }

--- a/scripts/smoke_generated_web.ps1
+++ b/scripts/smoke_generated_web.ps1
@@ -1,6 +1,8 @@
 param(
   [Parameter(Mandatory = $true, Position = 0)]
-  [string]$Cli
+  [string]$Cli,
+  [Parameter(Position = 1)]
+  [string]$FrameworkCommit = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -29,6 +31,20 @@ if (Test-Path $smokeRoot) {
 New-Item -ItemType Directory -Force $smokeRoot | Out-Null
 
 Invoke-Checked $cliPath new $appPath --type web --no-deps
+
+if ($FrameworkCommit) {
+  $shardPath = Join-Path $appPath "shard.yml"
+  $manifest = [System.IO.File]::ReadAllText($shardPath)
+  $releasedFramework = "    version: 2.0.0-beta.2"
+  if (-not $manifest.Contains($releasedFramework)) {
+    throw "Generated shard.yml does not contain the expected Amber beta pin"
+  }
+  $manifest = $manifest.Replace(
+    $releasedFramework,
+    "    commit: $FrameworkCommit"
+  )
+  [System.IO.File]::WriteAllText($shardPath, $manifest)
+}
 
 Push-Location $appPath
 try {


### PR DESCRIPTION
## What changed

- add a GitHub-hosted Linux ARM64 compile-and-smoke job
- add a GitHub-hosted Windows x86_64 compile job for the Amber CLI and a generated V2 web app
- add a PowerShell smoke script that generates the clean web scaffold, installs dependencies, runs its request spec, and compiles the application
- install the SQLite import library required by the CLI on Windows while preserving Crystal's bundled library path
- add `linux-arm64` to the release matrix, artifact verification, and upload list
- document the CLI 2.0.3 ARM64 source-build path until that archive ships

## Platform evidence

- Linux ARM64 passes against the released Amber 2.0.0-beta.2 dependency.
- A manual next-release workflow run built, smoke-tested, archived, checksummed, and uploaded the `linux-arm64` artifact alongside the existing targets: https://github.com/amberframework/amber_cli/actions/runs/31489541964
- Windows reaches project generation, dependency installation, and request specs against beta.2, then fails because Amber's controller-relative ECR macro assumes Unix path separators.
- The Windows job pins the generated app to the exact candidate framework commit from amberframework/amber#1402. With that fix, the complete Windows job passes, including the native application compile.

## Validation

- all pull-request checks pass, including Linux ARM64 and Windows x86_64 generated-app jobs
- Amber CLI test suite: 406 examples, 0 failures, 0 errors after building the required LSP test binary
- framework render-path regression spec: 7 examples, 0 failures
- full framework suite: 2,321 examples, 0 failures
- release workflow run: all three build targets passed; release-only upload jobs correctly skipped for the manual dispatch
- workflow YAML parsed locally and `git diff --check` passed

Windows is intentionally not a beta release gate. Its job should return to the released framework version pin after the fix ships in a new Amber beta.
