### PR TITLE
Pin Windows CI to merged framework fix

### DIFF
--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -30,7 +30,7 @@ jobs:
         run: scripts/smoke_generated_web.sh ./amber
 
   windows-x86-64:
-    name: Windows x86_64 generated web app (candidate framework fix)
+    name: Windows x86_64 generated web app (merged framework fix)
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -57,4 +57,4 @@ jobs:
 
       - name: Compile generated Amber V2 web app
         shell: pwsh
-        run: scripts/smoke_generated_web.ps1 ./amber.exe c95090f752f4cd01c0762c65e6398456631c2c0e
+        run: scripts/smoke_generated_web.ps1 ./amber.exe d044ea05e884b3247fd2af00859bde272aab676a


### PR DESCRIPTION
## Summary

- point the Windows generated-app job at the permanent merged commit from amberframework/amber#1402
- rename the job so its temporary release boundary is explicit

## Why

The first platform pull request proved the fix with its pre-merge commit. This follow-up avoids retaining a branch-only commit reference after the framework repair was squash-merged into `v2-dev`.

The job should return to the released Amber version pin after a later framework beta contains the fix. Windows remains outside the beta release gate.
